### PR TITLE
Fix editor disappearing in responsive mode

### DIFF
--- a/app/assets/stylesheets/problems.css.sass
+++ b/app/assets/stylesheets/problems.css.sass
@@ -64,7 +64,7 @@ pre.repl-log
         overflow: display
         height: 100% !important
 
-    interactive-terminal, .ace_editor
+    interactive-terminal, .editor .ace_editor
         height: 400px !important
     
     .form-group, .col-md-6, .ace_editor


### PR DESCRIPTION
Editor was disappearing in responsive mode on Problems show view. Minor fix.
